### PR TITLE
Add pagination params to alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make sure Livewire v3 is installed, then use the `collection:endless` tag:
             {{ partial:blog/post }}
         {{ /posts }}
     </div>
-    <button x-on:click="trigger">Load More</button>
+    <button x-on:click="trigger" x-show="paginate.has_more_pages">Load More</button>
 {{ /collection:endless }}
 ```
 

--- a/src/Livewire/Endless.php
+++ b/src/Livewire/Endless.php
@@ -112,10 +112,10 @@ class Endless extends Component
         
         $paginate = $params['paginate'];
         
-        $paginate['has_more_posts'] = $paginate['total_pages'] > $paginate['current_page'];
+        $paginate['has_more_pages'] = $paginate['total_pages'] > $paginate['current_page'];
 
         return collect($paginate)
-            ->only(['has_more_posts', 'total_pages', 'current_page', 'total_items', 'items_per_page'])
+            ->except(['auto_links'])
             ->all();        
     }
 }


### PR DESCRIPTION
This PR makes a paginate variable available to alpine, which contains all of Statamics variables (except auto_links), and a new has_more_pages variable to avoid devs having to do a calculation.